### PR TITLE
Fix broken sdist/wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
-
+from setuptools import setup, find_packages
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -22,7 +21,9 @@ setup(
     description="A pytest plugin to doctest your markdown files",
     long_description=readme,
     long_description_content_type="text/markdown",
-    py_modules=["pytest_markdoctest"],
+    # py modules is for single files, not folders.
+    # py_modules=["pytest_markdoctest"],
+    packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=requirements,


### PR DESCRIPTION
This will fix the sdist and wheel, which depending on how they are build, will omit all the source code, causing `ModuleNotFoundError: No module named 'pytest_markdoctest'` when you run pytest.

If anyone else finds this, this is the work around I'm using in the meanwhile

`python -m pip install 'pytest-markdoctest @ git+https://github.com/matthewdeanmartin/pytest-markdoctest@50d08c3c8ec30bc4c7dc56201bba26f5e8dacf2d'`

You will want to run `python setup.py bdist_wheel sdist` and pay close attention to the logging to see if the `__init__.py` and `unparse.py` were included.

For issue https://github.com/liqimai/pytest-markdoctest/issues/1