### PR TITLE
Fix AttributeError from DoctestMarkdown

### DIFF
--- a/src/pytest_markdoctest/__init__.py
+++ b/src/pytest_markdoctest/__init__.py
@@ -127,7 +127,7 @@ class DoctestMarkdown(pytest.Module):
         name = self.path.name
         globs = {"__name__": "__main__"}
 
-        optionflags = get_optionflags(self)
+        optionflags = get_optionflags(self.config)
 
         runner = MarkDoctestRunner(
             verbose=False,


### PR DESCRIPTION
Tried this package in a fresh venv today (using the `pip install` command from #2 ), and `pytest` hit `AttributeError: 'DoctestMarkdown' object has no attribute 'getini'` before even starting the doctests.

This PR fixes that. Since this repo appears inactive/abandoned, I have replicated this PR over at https://github.com/matthewdeanmartin/pytest-markdoctest/pull/1